### PR TITLE
scipy, numbaインストール関連を修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ RUN chsh -s /bin/zsh
 
 # C++, Python3, PyPy3の3つの環境想定
 RUN apt-get update && \
-    apt-get install -y gcc-9 g++-9 python3.8 python3-pip pypy3 nodejs npm
+    apt-get install -y gcc-9 g++-9 gfortran python3.8 python3-pip pypy3 nodejs npm liblapack-dev llvm-7
 
 # 一般的なコマンドで使えるように設定
 # e.g. python3.8 main.py => python main.py
@@ -26,9 +26,12 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 30 && \
     update-alternatives --install /usr/bin/pypy pypy /usr/bin/pypy3 30 && \
     update-alternatives --install /usr/bin/node node /usr/bin/nodejs 30
 
+# LLVMのパスを設定
+ENV LLVM_CONFIG=/usr/lib/llvm-7/bin/llvm-config
 # AtCoderでも使えるPythonライブラリをインストール
 RUN pip install numpy==1.18.2 && \
     pip install scipy==1.4.1 && \
+    pip install cython && \
     pip install scikit-learn==0.22.2.post1 && \
     pip install numba==0.48.0 && \
     pip install networkx==2.4


### PR DESCRIPTION
# 変更の概要

* gfortranコンパイラ, LAPACK, LLVMのインストールを追加しました

## なぜこの変更をするのか

* scipy, numbaのビルド時に、上記パッケージが無く失敗するため

## やったこと

dockerfileを下記のように修正しました。
```dockerfile
# Fortran, liblapack-dev, llvm-7のインストールを追加

# C++, Python3, PyPy3の3つの環境想定
RUN apt-get update && \
#    apt-get install -y gcc-9 g++-9 python3.8 python3-pip pypy3 nodejs npm
    apt-get install -y gcc-9 g++-9 gfortran python3.8 python3-pip pypy3 nodejs npm liblapack-dev llvm-7
```

```dockerfile
# LLVMのパスを設定
ENV LLVM_CONFIG=/usr/lib/llvm-7/bin/llvm-config

# cythonをインストール
RUN pip install cython
```

## 備考
* 環境
    * macOS 12.01 Monterey
    * Apple Silicon (M1)
    * コンテナのベースOS = Ubuntu 20.04.3 LTS (Focal Fossa)